### PR TITLE
Bumped from Ruby 2.6.6 to 2.7

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Change log for Docker-cheatset
 
+## 0.3.0 2021-02-07 Maintenance release
+
+- Bumped from Ruby 2.6.6 to 2.7
+
+- Warnings on URI being deprecated, have created [a PR upstream](https://github.com/Kapeli/cheatset/pull/35) exchanging URI for CGI as [per recommendation from the documentation](https://rubyapi.org/2.7/o/uri/escape)
+
 ## 0.2.0 2020-06-06 Maintenance release
 
 - dependabot provided a PR updating ruby from 2.5-stretch to 2.6.6-stretch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.6-stretch
+FROM ruby:2.7-buster
 
 RUN gem install cheatset
 


### PR DESCRIPTION
Warnings on URI being deprecated, have created [a PR upstream](https://github.com/Kapeli/cheatset/pull/35) exchanging URI for CGI as [per recommendation from the documentation](https://rubyapi.org/2.7/o/uri/escape)