### PR TITLE
Bumped based image to 3.2.6 from 3.2.3

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Change log for Docker-cheatset
 
+## 0.17.0 2024-11-10 Maintenance release
+
+- Bumped Docker base image from Ruby 3.2.3-slim-bullseye to 3.2.6-slim-bullseye, via PR [#108](https://github.com/jonasbn/docker-cheatset/pull/108) from @jonasbn
+
 ## 0.16.0 2024-07-18 Maintenance release
 
 - Bumped Docker base image from Ruby 3.2.2-slim-bullseye to 3.2.3-slim-bullseye, via PR [#82](https://github.com/jonasbn/docker-cheatset/pull/82) from @snyk-bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # REF: https://docs.docker.com/engine/reference/builder/
 # REF: https://hub.docker.com/_/ruby
-FROM ruby:3.2.3-slim-bullseye
+FROM ruby:3.2.6-slim-bullseye
 
 # We point to the original repository for the image
 LABEL org.opencontainers.image.source=https://github.com/jonasbn/docker-cheatset


### PR DESCRIPTION
Bumped based image to 3.2.6 from 3.2.3, this does seem to address a lot of the security advisories for the base image.

Was unable to replicate #97 

So I believe we can close that one.