### PR TITLE
Support for ARM64 and other improvements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,15 @@
 name: Publish to DockerHub
 
 on:
-  schedule:
-  - cron: "0 0 */28 */1 *"
   push:
     branches: 
     - master
+    tags:
+      - "*"
+
+permissions:
+  contents: read
+  packages: write
 
 jobs:
   dockerhub-publish:
@@ -15,31 +19,32 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
       -
         name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # ratchet:docker/setup-qemu-action@v3
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # ratchet:docker/setup-buildx-action@v3
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # ratchet:docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
         name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 # ratchet:docker/build-push-action@v6
         with:
-          context: .
-          file: ./Dockerfile
+          platforms: "linux/amd64,linux/arm64"
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: |
             jonasbn/cheatset:latest
       - 
         name: Docker Hub Description
-        uses: peter-evans/dockerhub-description@v4
+        uses: peter-evans/dockerhub-description@432a30c9e07499fd01da9f8a49f0faf9e0ca5b77 # ratchet:peter-evans/dockerhub-description@v4.0.2 
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -28,3 +28,4 @@ snyk
 suredream
 tmp
 toolchain
+kspeeckaert

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,15 @@
 # Change log for Docker-cheatset
 
+## 0.18.0 2025-05-21 Feature/maintenance release
+
+- Bumped Docker base image from Ruby 3.2.6-slim-bullseye to 3.2.8-slim-bookworm
+
+- Pinned Docker base image
+
+- Pinned GitHub Actions
+
+- Added build of arm64 architecture/platform as requested by @kspeeckaert via issue [#123](https://github.com/jonasbn/docker-cheatset/issues/123)
+
 ## 0.17.0 2024-11-10 Maintenance release
 
 - Bumped Docker base image from Ruby 3.2.3-slim-bullseye to 3.2.6-slim-bullseye, via PR [#108](https://github.com/jonasbn/docker-cheatset/pull/108) from @jonasbn

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # REF: https://docs.docker.com/engine/reference/builder/
 # REF: https://hub.docker.com/_/ruby
-FROM ruby:3.2.6-slim-bullseye
+FROM ruby:3.2.8-slim-bookworm@sha256:b42a6ec7c24b0105241429d41cab49c5d6d57e5b0df8c86cdf54cc405b9c3c79
 
 # We point to the original repository for the image
 LABEL org.opencontainers.image.source=https://github.com/jonasbn/docker-cheatset


### PR DESCRIPTION
- Bumped base image from 3.2.6 to 3.2.8, plus bullseye to bookworm and pinned the image to the SHA
- Pinned GitHub Actions. Added arm64 platform/architecture requested #123

Closing #123
