### PR TITLE
docs: add TODO tracking post-Ruby-4.0-upgrade follow-ups

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,7 +4,7 @@
 
 `Gemfile.lock` carries `BUNDLED WITH 2.4.20`, which predates the Bundler version
 that ships with Ruby 4.0's gem ecosystem. No failure has been observed yet, but if a
-future build step raises a Bundler version mismatch warning this is the first place to
+future build step raises a Bundler version mismatch warning, this is the first place to
 look. Regenerate `Gemfile.lock` with the Bundler version included in the Ruby 4.0 image
 to eliminate the discrepancy.
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,15 @@
+# TODO
+
+## Bundler version compatibility (Ruby 4.0 upgrade)
+
+`Gemfile.lock` carries `BUNDLED WITH 2.4.20`, which predates the Bundler version
+that ships with Ruby 4.0's gem ecosystem. No failure has been observed yet, but if a
+future build step raises a Bundler version mismatch warning this is the first place to
+look. Regenerate `Gemfile.lock` with the Bundler version included in the Ruby 4.0 image
+to eliminate the discrepancy.
+
+## container-structure-test candidate config is stale
+
+`docs/container-structure-test.md` contains a candidate YAML snippet that asserts
+`cheatset version is 1.4.6`. This should be updated to `1.5.0` before the config is
+promoted to an actual test file.


### PR DESCRIPTION
Notes two items found during PR #182 review: the Bundler version
mismatch in Gemfile.lock (BUNDLED WITH 2.4.20 vs Ruby 4.0's bundler),
and the stale cheatset version reference in the container-structure-test
candidate config.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DCp9Aenu5eQA5i8uFYejac